### PR TITLE
⚙️ FIX error tags html5 borradas

### DIFF
--- a/course/format/remuiformat/classes/output/card_one_section_renderable.php
+++ b/course/format/remuiformat/classes/output/card_one_section_renderable.php
@@ -291,7 +291,8 @@ class format_remuiformat_card_one_section implements renderable, templatable {
                         $mod,
                         $displayoptions
                     );
-                    $activitydetails->fullcontent = format_text($activitydetails->fullcontent, FORMAT_HTML);
+                    //TODO: $activitydetails->fullcontent = format_text($activitydetails->fullcontent, FORMAT_HTML);
+                    //TODO: Actualización del componente rompe el contenido html5, tener en revisión hacia una nueva actualización o rollback descomentar si se ha hallado una solución limpia
                 }
 
                 $activitydetails->completed = $completiondata->completionstate;


### PR DESCRIPTION
El error se debe a una actualización de moodle que modifica el componente/plugin edwiser, el componente con la actualización bloquea por defecto las etiquetas html5, la solución implica edición del core para evitar ese filtrado, para una solución limpia se debe considerar el filtrado html de moodle, los parámetros de seguridad o errores de la actualización de edwiser y el monitoreo al comportamiento del editor. Se recomienda revisar actualizaciones y documentación del componente/plugin

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
